### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ And then run `sudo update-grub`.
 
 Alternatively if your distribution doesn't have that command you can run `sudo grub-mkconfig -o /boot/grub/grub.cfg`
 
-Running `sudo ./set_matter.sh` creates a directory in `/boot/grub/themes` called "Matter". If you want to delete the theme completely it is safe remove this directory after completing the steps above.
+Running `sudo ./set_matter.sh` creates a directory in `/boot/grub/themes` called "Matter". If you want to delete the theme completely it is safe to remove this directory after completing the steps above.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ GRUB_THEME="/boot/grub/themes/Matter/theme.txt"
 ```
 And then run `sudo update-grub`.
 
-Or alternatively if your distribution doesn't have that command you can run `sudo grub-mkconfig -o /boot/grub/grub.cfg`
+Alternatively if your distribution doesn't have that command you can run `sudo grub-mkconfig -o /boot/grub/grub.cfg`
 
 Running `sudo ./set_matter.sh` creates a directory in `/boot/grub/themes` called "Matter". If you want to delete the theme completely it is safe remove this directory after completing the steps above.
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ Run `sudo ./set-matter.sh -p blue` for blue theme.
 
 # Removal
 
-You can delete or comment this line in your `/etc/default/grub` file
+You can delete or comment this line in your `/etc/default/grub` file to disable the theme
 ```
 GRUB_THEME="/boot/grub/themes/Matter/theme.txt"
 ```
 And then run `sudo update-grub`.
+
+Or alternatively if your distribution doesn't have that command you can run `sudo grub-mkconfig -o /boot/grub/grub.cfg`
+
+Running `sudo ./set_matter.sh` creates a directory in `/boot/grub/themes` called "Matter". If you want to delete the theme completely it is safe remove this directory after completing the steps above.
 
 # Contributing
 


### PR DESCRIPTION
Adds the command `sudo grub-mkconfig -o /boot/grub/grub.cfg` to the readme file for distributions where `sudo update-grub` is not an option.

Also adds instructions to remove the Matter directory in `/boot/grub/themes` in case the user wants to remove the theme completely.