### PR TITLE
Remove repetitive code in set-matter.sh

### DIFF
--- a/set-matter.sh
+++ b/set-matter.sh
@@ -50,28 +50,28 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
 
   # Setting palette color  
   # List of supported colors
-  supported_colors=(red pink purple deep-purple blue cyan teal green yellow orange gray white)
+  supported_colors=(red pink purple deep_purple blue cyan teal green yellow orange gray white)
   
   # Hex values for the supported colors
-  colors[red]="#F44336"
-  colors[pink]="#E91E63"
-  colors[purple]="#9C27B0"
-  colors[deep-purple]="#673AB7"
-  colors[blue]="#2196F3"
-  colors[cyan]="#00BCD4"
-  colors[teal]="#009688"
-  colors[green]="#4CAF50"
-  colors[yellow]="#FFEB3B"
-  colors[orange]="#FF9800"
-  colors[gray]="#9E9E9E"
-  colors[white]="#FFFFFF"
+  red="#F44336"
+  pink="#E91E63"
+  purple="#9C27B0"
+  deep_purple="#673AB7"
+  blue="#2196F3"
+  cyan="#00BCD4"
+  teal="#009688"
+  green="#4CAF50"
+  yellow="#FFEB3B"
+  orange="#FF9800"
+  gray="#9E9E9E"
+  white="#FFFFFF"
 
   # Set the chosen color if it is supported
   if [[ " ${supported_colors[@]} " =~ " ${PALETTE} " ]]; then
       echo -e "Setting theme to ${PALETTE}"
-      sed -i -E "s/(selected_item_color = )\"#[0-9a-fA-F]+\"/\1\"${colors[${PALETTE}]}\"/" "${THEME_DIR}/${THEME_NAME}/theme.txt"
+      sed -i -E "s/(selected_item_color = )\"#[0-9a-fA-F]+\"/\1\"${!PALETTE}\"/" "${THEME_DIR}/${THEME_NAME}/theme.txt"
   fi
-
+  
   # Set theme
   echo -e "Setting ${THEME_NAME} as default..."
   grep "GRUB_THEME=" /etc/default/grub 2>&1 >/dev/null && sed -i '/GRUB_THEME=/d' /etc/default/grub

--- a/set-matter.sh
+++ b/set-matter.sh
@@ -48,65 +48,28 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
   [[ -d /boot/grub ]] && cp -a ${THEME_NAME} ${THEME_DIR}
   [[ -d /boot/grub2 ]] && cp -a ${THEME_NAME} ${THEME_DIR_2}
 
-  # Setting palette color
-  if [ "${PALETTE}" == "red" ]; then
-    echo -e "Setting theme to red"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#F44336"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
+  # Setting palette color  
+  # List of supported colors
+  supported_colors=(red pink purple deep-purple blue cyan teal green yellow orange gray white)
+  
+  # Hex values for the supported colors
+  colors[red]="#F44336"
+  colors[pink]="#E91E63"
+  colors[purple]="#9C27B0"
+  colors[deep-purple]="#673AB7"
+  colors[blue]="#2196F3"
+  colors[cyan]="#00BCD4"
+  colors[teal]="#009688"
+  colors[green]="#4CAF50"
+  colors[yellow]="#FFEB3B"
+  colors[orange]="#FF9800"
+  colors[gray]="#9E9E9E"
+  colors[white]="#FFFFFF"
 
-  if [ "${PALETTE}" == "pink" ]; then
-    echo -e "Setting theme to pink"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#E91E63"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "purple" ]; then
-    echo -e "Setting theme to purple"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#9C27B0"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "deep-purple" ]; then
-    echo -e "Setting theme to deep purple"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#673AB7"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "blue" ]; then
-    echo -e "Setting theme to blue"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#2196F3"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "cyan" ]; then
-    echo -e "Setting theme to cyan"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#00BCD4"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "teal" ]; then
-    echo -e "Setting theme to teal"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#009688"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "green" ]; then
-    echo -e "Setting theme to green"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#4CAF50"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "yellow" ]; then
-    echo -e "Setting theme to yellow"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#FFEB3B"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "orange" ]; then
-    echo -e "Setting theme to orange"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#FF9800"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "gray" ]; then
-    echo -e "Setting theme to gray"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#9E9E9E"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
-  fi
-
-  if [ "${PALETTE}" == "white" ]; then
-    echo -e "Setting theme to white"
-    sed -i -E 's/(selected_item_color = )"#[0-9a-fA-F]+"/\1"#FFFFFF"/' "${THEME_DIR}/${THEME_NAME}/theme.txt"
+  # Set the chosen color if it is supported
+  if [[ " ${supported_colors[@]} " =~ " ${PALETTE} " ]]; then
+      echo -e "Setting theme to ${PALETTE}"
+      sed -i -E "s/(selected_item_color = )\"#[0-9a-fA-F]+\"/\1\"${colors[${PALETTE}]}\"/" "${THEME_DIR}/${THEME_NAME}/theme.txt"
   fi
 
   # Set theme


### PR DESCRIPTION
Remove repetitive code for palette color in `set-matter.sh` as requested in #20 