### PR TITLE
Remove unnecessary grep

### DIFF
--- a/set-matter.sh
+++ b/set-matter.sh
@@ -74,7 +74,7 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
   
   # Set theme
   echo -e "Setting ${THEME_NAME} as default..."
-  grep "GRUB_THEME=" /etc/default/grub 2>&1 >/dev/null && sed -i '/GRUB_THEME=/d' /etc/default/grub
+  sed -i '/GRUB_THEME=/d' /etc/default/grub
 
   [[ -d /boot/grub ]] && echo "GRUB_THEME=\"${THEME_DIR}/${THEME_NAME}/theme.txt\"" >> /etc/default/grub
   [[ -d /boot/grub2 ]] && echo "GRUB_THEME=\"${THEME_DIR_2}/${THEME_NAME}/theme.txt\"" >> /etc/default/grub


### PR DESCRIPTION
If 'GRUB_THEME=' line doesn't exist in /etc/default/grub, then sed will just exit successfully.

Minor code clean-up  (#20) 