### PR TITLE
 Added custom background feature as per #56 

### DIFF
--- a/matter.py
+++ b/matter.py
@@ -313,11 +313,27 @@ def prepare_source_dir():
     highlight = parse_color(user_args.highlight)
     foreground = parse_color(user_args.foreground)
     background = parse_color(user_args.background)
+    image = user_args.image
     fontkey = user_args.font
     fontfile = user_args.fontfile
     fontname = user_args.fontname
     fontsize = user_args.fontsize
     icons = user_args.icons
+
+    # Image checks
+    if image:
+        if not exists(image):
+            error(
+                f"{image} does not exist!")
+        if os.path.splitext(image)[1] not in ('.png', '.tga', '.jpg', '.jpeg'):
+            error(
+                f"Background image must be one of .png, .tga, .jpg or .jpeg formats.")
+        image_name = basename(image)
+        copyfile(image, f"{INSTALLATION_SOURCE_DIR}/{image_name}")
+        if background:
+            warning(f"Both --background and --image arguments specified. Background color {background} will be ignored.")
+    else:
+        image_name = "background.png"
 
     # Icon checks
     # Read entries from grub.cfg
@@ -393,9 +409,13 @@ def prepare_source_dir():
         "highlight": highlight,
         "foreground": foreground,
         "background": background,
+        "image_name": image_name,
         "fontname": fontname,
     }
     parsed_theme = template.format(**context)
+
+    if image:
+        parsed_theme = parsed_theme.replace("# desktop-image", "desktop-image")
 
     theme_file_path = f"{INSTALLATION_SOURCE_DIR}/theme.txt"
     with open(theme_file_path, "w") as f:
@@ -712,6 +732,12 @@ def parse_args():
         type=str,
         help=f"solid background color",
         default=THEME_DEFAULT_BACKGROUND,
+    )
+    parser.add_argument(
+        "--image",
+        "-im",
+        type=str,
+        help=f"image file to use as background",
     )
     parser.add_argument(
         "--iconcolor",

--- a/matter.py
+++ b/matter.py
@@ -541,7 +541,7 @@ def do_install():
     do_set_icons()
     install_hookcheck()
     update_grub_cfg()
-    info(f"{THEME_NAME} succesfully installed")
+    info(f"{THEME_NAME} successfully installed")
 
 
 def do_uninstall():

--- a/theme.txt.template
+++ b/theme.txt.template
@@ -9,7 +9,7 @@
 
 # Global Property
 title-text: ""
-# desktop-image: "background.png"
+# desktop-image: "{image_name}"
 desktop-color: "{background}"
 terminal-font: "default" # a random name to let the default font for the console
 terminal-box: "terminal_box_*.png"


### PR DESCRIPTION
I hope you're okay with this. Tested to work on my device. 3 small concerns though:
1. If the user reruns the script with a new image or without any image, the old image will remain in /boot/grub/themes/Matter. Is that a problem?
2. Can consider other arguments too, I'm not sure what is the clearest - background-image, bg-image, image-file, or a combination of these.
3. Can update readme for a small section on how to use this, and select a free image to showcase under gallery. I wanted to add a picture from https://github.com/vinceliuice/grub2-themes, but because it has a GPL-3.0 License while Matter has no license, I don't think we can. I'm not too sure about all these licensing stuffs.