### PR TITLE
Added --all-icon-colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-.vscode
 Matter/icons/*.png
 Matter/font.pf2
 icons/*.svg
 fonts/*.ttf
+config.json
 __pycache__
+.vscode

--- a/matter.py
+++ b/matter.py
@@ -17,6 +17,7 @@ from utils import *
 from svg2png import inkscape_convert_svg2png, magick_convert_svg2png
 
 #region Configuration constants
+
 MIN_PYTHON_VERSION = (3, 6)  # Mainly for f-strings
 
 THEME_NAME = "Matter"
@@ -24,6 +25,8 @@ THEME_DESCRIPTION = (
     "Matter is a minimalist grub theme originally inspired by material design 2.\n"
     "Run this script without arguments for next steps on installing Matter."
 )
+
+
 
 if exists("/boot/grub"):
     BOOT_GRUB_PATH = "/boot/grub"
@@ -108,19 +111,23 @@ def check_python_version():
     if installed < required:
         error(f"Python {required[0]}.{required[1]} or later required")
 
+
 def check_root_or_prompt():
     if os.geteuid() != 0:
         info("Request root access")
         exit_code = sh("sudo -v")
-        if exit_code != 0: error("Could not verify root access, you could try with sudo")
+        if exit_code != 0:
+            error("Could not verify root access, you could try with sudo")
         # Relaunch the program with sudo
         args = " ".join(sys.argv[1:])
         child_exit_code = sh(f"sudo {INSTALLER_DIR}/{INSTALLER_NAME} {args}")
         exit(child_exit_code)  # Propagate exit code
 
+
 def delete_dir(directory):
     if isdir(directory):
         rmtree(directory)
+
 
 def read_cleaned_grub_defaults():
     # Read previous defaults
@@ -136,6 +143,7 @@ def read_cleaned_grub_defaults():
     )
     return cleaned_grub_defaults
 
+
 def read_cleaned_grub_mkconfig():
     # Read previous defaults
     with open(GRUB_MKCONFIG_PATH, "r", newline="") as f:
@@ -149,6 +157,7 @@ def read_cleaned_grub_mkconfig():
         flags=re.DOTALL,
     )
     return cleaned_grub_mkconfig
+
 
 def download_icon(icon_name):
     info(f"Download {icon_name}.svg")
@@ -165,6 +174,7 @@ def download_icon(icon_name):
         f.write(response)
     return svg_path
 
+
 def get_converted_icons():
     return [
         filename[:-4]  # Remove .png
@@ -172,63 +182,68 @@ def get_converted_icons():
         if filename.endswith(".png")
     ]
 
+
 def is_icon_downloaded(icon_name):
     svg_path = ICON_SVG_PATHF.format(icon_name)
     return exists(svg_path)
 
-def convert_icons_svg2png():
+
+def convert_icon_svg2png():
     if not has_command("inkscape"):
         if not has_command("convert"):
-            error("Stop. Both `inkscape` and `convert` command from imagemagick was not found", "Consider installing `inkscape` for the best results")
-        else: command = "convert"
-    else: command = "inkscape"
-
+            error(
+                "Stop. Both `inkscape` and `convert` command from imagemagick was not found",
+                "Consider installing `inkscape` for the best results",
+            )
+        else:
+            command = "convert"
+    else:
+        command = "inkscape"
+    
     if (user_args.all_icon_colors is not None) and (command == "inkscape"):
-        icons = []
-        colors = []
+        icons = [
+            filename[:-4]
+            for filename in os.listdir(f"icons/")
+            if (filename[:-4] in user_args.icons)
+            if (filename.endswith(".svg"))
+        ]
+        colors = check_colors()
+
         svg2png = inkscape_convert_svg2png
 
-        for _ in user_args.icons:
-            try: icons.index(_)
-            except ValueError: icons.append(_)
-        print(icons)
+        #? Converting Icons
+        for icon in icons:
+            src_path = ICON_SVG_PATHF.format(icon)
+            dst_path = ICON_PNG_PATHF.format(icon)
+            
+            info(f"Icon: {icon}")
+            exit_code = svg2png(colors[icons.index(icon)], src_path, dst_path, whisper=True)
+            if exit_code != 0: error(f"Stop. The `{svg2png}` command returned an error")
 
-        for _ in user_args.all_icon_colors:
-            color = parse_color(_)
-            try: colors.index(color)
-            except ValueError: colors.append(color)
-        print(colors)
-
-        for _ in icons:
-            src_path = ICON_SVG_PATHF.format(_)
-            dst_path = ICON_PNG_PATHF.format(_)
-            info(f"Icon: {_}")
-            exit_code = svg2png(colors[icons.index(_)], src_path, dst_path, whisper=True)
-            if exit_code != 0: error(f"Stop. The `{command}` command returned an error")
-        print(icons)
-        print(colors)
     else:
-        icons = []
+        icons = [
+            filename[:-4]
+            for filename in os.listdir(f"icons/")
+            if (filename[:-4] in user_args.icons)
+            if (filename.endswith(".svg"))
+        ]
 
-        for _ in user_args.icons:
-            try: icons.index(_)
-            except ValueError: icons.append(_)
-
-        for _ in icons:
-            src_path = ICON_SVG_PATHF.format(_)
-            dst_path = ICON_PNG_PATHF.format(_)
+        for icon in icons:
+            src_path = ICON_SVG_PATHF.format(icon)
+            dst_path = ICON_PNG_PATHF.format(icon)
             color = (
                 parse_color(user_args.iconcolor)
                 if user_args.iconcolor
                 else parse_color(user_args.foreground)
             )
 
-            if command == "convert": svg2png = magick_convert_svg2png
-            elif command == "inkscape": svg2png = inkscape_convert_svg2png
+            if svg2png == "convert": svg2png = magick_convert_svg2png
+            elif svg2png == "inkscape": svg2png = inkscape_convert_svg2png
 
-            info(f"Icon: {_}")
+            info(f"Icon: {icon}")
             exit_code = svg2png(color, src_path, dst_path, whisper=True)
-            if exit_code != 0: error(f"Stop. The `{command}` command returned an error")
+            if exit_code != 0: error(f"Stop. The `{svg2png}` command returned an error")
+
 
 def get_available_fonts():
     "Returns the fonts present in /fonts"
@@ -238,23 +253,53 @@ def get_available_fonts():
         if filename.endswith(".ttf")
     ]
 
+
 def parse_color(color_string):
-    if color_string in AVAILABLE_COLORS:
+    if color_string == "_":
+        return color_string
+    elif color_string in AVAILABLE_COLORS:
         color = PALETTE[color_string]
     elif re.match(r"[0-9A-Fa-f]{6}", color_string) is not None:
         color = color_string
     else:
         error(
             f"Invalid color parsed from {color_string}",
-            f"Color must be an hex code like C0FFEE or one of: {AVAILABLE_COLORS}",
+            f"Color must be an hex code like C00FFE or one of: {AVAILABLE_COLORS}",
         )
     return f"#{color}"
+
+
+def check_colors():
+
+    colors = user_args.all_icon_colors
+
+    if colors is None:
+        error("Stop. Unspecified colors (--all-icon-colors/-aic argument)")
+    colors = [parse_color(c) for c in colors]
+
+    # Read current grub cfg
+    entries = get_entry_names()
+    if len(colors) != len(entries):
+        error(
+            f"You must specify {len(entries)} "
+            f"colors ({len(colors)} provided) for entries:",
+            should_exit=False,
+        )
+        for i, m in enumerate(entries):
+            print(f"{i + 1}. {m['entryname']}")
+        # NOTE: We exit with 0 here to not stop the apt upgrade process
+        # eventually it will be solved with an autoremove
+        exit(0)
+    
+    return colors
+
 
 def check_icon_converted(icon):
     available_icons = get_converted_icons()
     if icon not in available_icons + ["_"]:
         error(f"Invalid icon name: {icon}", f"Icons present are: {available_icons}")
     return icon
+
 
 def parse_font(font):
     """From a given --font check if available and return its font name
@@ -266,12 +311,15 @@ def parse_font(font):
         )
     return font.replace("_", " ")
 
+
 # Procedures
+
 
 def clean_install_dir():
     info("Clean install directory")
     if isdir(INSTALLATION_TARGET_DIR):
         rmtree(INSTALLATION_TARGET_DIR)
+
 
 def prepare_source_dir():
     info("Build theme from user preferences")
@@ -299,7 +347,9 @@ def prepare_source_dir():
         image_name = basename(image)
         copyfile(image, f"{INSTALLATION_SOURCE_DIR}/{image_name}")
         if user_args.background:
-            warning(f"Both --background and --image arguments specified. Background color {background} will be ignored.")
+            warning(
+                f"Both --background and --image arguments specified. Background color {background} will be ignored."
+            )
     else:
         image_name = "background.png"
 
@@ -308,7 +358,10 @@ def prepare_source_dir():
     entries = get_entry_names()
     # Do icon count match grub entry count?
     if len(icons) != len(entries):
-        error(f"You must specify {len(entries)} icons ({len(icons)} provided) for entries:", should_exit=False)
+        error(
+            f"You must specify {len(entries)} icons ({len(icons)} provided) for entries:",
+            should_exit=False,
+        )
         for i, m in enumerate(entries):
             print(f"{i + 1}. {m['entryname']}")
         exit(1)
@@ -325,7 +378,10 @@ def prepare_source_dir():
     elif not fontfile.endswith(".ttf"):  # font file is not ttf
         error(f"{fontfile} is not a .ttf file")
     elif fontname is None:  # User did, but did not gave its name
-        error("--fontname/-fn not specified for given font file.", "e.g. 'Open Sans Regular'")
+        error(
+            "--fontname/-fn not specified for given font file.",
+            "e.g. 'Open Sans Regular'",
+        )
     else:  # User specified a custom fontfile
         fontname = " ".join(fontname)  # e.g. Open Sans Regular
         dst_fontfile = f"{INSTALLER_DIR}/fonts/{fontname.replace(' ', '_')}.ttf"  # e.g. .../Open_Sans_Regular.ttf
@@ -342,15 +398,19 @@ def prepare_source_dir():
 
     # Convert icons
     info("Convert icons")
-    convert_icons_svg2png()
+    convert_icon_svg2png()
 
     # Prepare Font
 
     # Generate font file
     info("Build font")
-    stdout = shout(f"{grub_mkfont} -o {INSTALLATION_SOURCE_DIR}/font.pf2 {fontfile} -s {fontsize}")
+    stdout = shout(
+        f"{grub_mkfont} -o {INSTALLATION_SOURCE_DIR}/font.pf2 {fontfile} -s {fontsize}"
+    )
     if stdout:
-        error(f"{grub_mkfont} execution was not clean", f"for fontfile: {fontfile}")
+        error(
+            f"{grub_mkfont} execution was not clean", f"for fontfile: {fontfile}",
+        )
 
     # Prepare Theme.txt
 
@@ -368,19 +428,23 @@ def prepare_source_dir():
     }
     parsed_theme = template.format(**context)
 
-    if image: parsed_theme = parsed_theme.replace("# desktop-image", "desktop-image")
+    if image:
+        parsed_theme = parsed_theme.replace("# desktop-image", "desktop-image")
 
     theme_file_path = f"{INSTALLATION_SOURCE_DIR}/theme.txt"
     with open(theme_file_path, "w") as f:
         f.write(parsed_theme)
 
+
 def prepare_target_dir():
     info("Prepare installation directory")
     clean_install_dir()
 
+
 def copy_source_to_target():
     info("Copy built theme to installation directory")
     copytree(INSTALLATION_SOURCE_DIR, INSTALLATION_TARGET_DIR)
+
 
 def update_grub_cfg():
     info("Update grub.cfg")
@@ -394,6 +458,7 @@ def update_grub_cfg():
     command = f"{update_command} -o {GRUB_CFG_PATH}"
     info(f"Remake grub.cfg with {command}")
     sh(command)
+
 
 def update_grub_defaults():
     info(f"Patch {GRUB_DEFAULTS_PATH} with {THEME_OVERRIDES_TITLE}")
@@ -413,11 +478,13 @@ def update_grub_defaults():
     with open(GRUB_DEFAULTS_PATH, "w") as f:
         f.write(grub_configs)
 
+
 def clean_grub_defaults():
     info(f"Clean {THEME_OVERRIDES_TITLE} from {GRUB_DEFAULTS_PATH}")
     cleaned_grub_defaults = read_cleaned_grub_defaults()
     with open(GRUB_DEFAULTS_PATH, "w") as f:
         f.write(cleaned_grub_defaults)
+
 
 def clean_grub_mkconfig():
     info(f"Clean {THEME_OVERRIDES_TITLE} from {GRUB_MKCONFIG_PATH}")
@@ -425,11 +492,13 @@ def clean_grub_mkconfig():
     with open(GRUB_MKCONFIG_PATH, "w") as f:
         f.write(cleaned_grub_mkconfig)
 
+
 def clean_hookcheck():
     info(f"Remove hookcheck script from {GRUB_SCRIPTS_PATH}")
     hookcheck = f"{GRUB_SCRIPTS_PATH}/99_matter"
     if exists(hookcheck):
         os.remove(hookcheck)
+
 
 def get_entry_names():
     "Gets the entry names from grub.cfg contents"
@@ -446,7 +515,9 @@ def get_entry_names():
     matches = list(matchiter)
     return matches
 
+
 # Main procedures
+
 
 def do_preinstall_hint():
     info(
@@ -464,6 +535,7 @@ def do_preinstall_hint():
     info("Example (with 8 entries, _ means ignore):")
     info("./matter.py -i ubuntu microsoft-windows folder _ _ _ _ cog")
 
+
 def do_test():
     info("Begin grub2-theme-preview")
     warning(
@@ -478,9 +550,10 @@ def do_test():
         )
     sh(f"grub2-theme-preview {INSTALLATION_SOURCE_DIR}")
 
+
 def do_install():
-    check_root_or_prompt()
     info(f"Begin {THEME_NAME} install")
+    check_root_or_prompt()
     prepare_source_dir()
     prepare_target_dir()
     copy_source_to_target()
@@ -489,6 +562,7 @@ def do_install():
     install_hookcheck()
     update_grub_cfg()
     info(f"{THEME_NAME} successfully installed")
+
 
 def do_uninstall():
     info(f"Begin {THEME_NAME} uninstall")
@@ -500,6 +574,7 @@ def do_uninstall():
     update_grub_cfg()
     info(f"{THEME_NAME} successfully uninstalled")
 
+
 def do_list_grub_cfg_entries():
     # Read current grub cfg
     with open(GRUB_CFG_PATH, "r", newline="") as f:
@@ -509,6 +584,7 @@ def do_list_grub_cfg_entries():
 
     for i, m in enumerate(entries):
         print(f"{i + 1}. {m['entryname']}")
+
 
 def create_config_file():
     icons = user_args.icons
@@ -526,6 +602,7 @@ def create_config_file():
 
     with open(CONFIG_FILE_PATH, 'w') as f:
         f.write(json.dumps(config))
+
 
 def patch_from_config_file():
     # Read current grub cfg
@@ -550,7 +627,9 @@ def patch_from_config_file():
 
     do_patch_grub_cfg_icons(icons)
 
+
 def do_patch_grub_cfg_icons(icons):
+
     info(f"Begin {GRUB_CFG_PATH} patch")
     with open(GRUB_CFG_PATH, "r", newline="") as f:
         grub_cfg = f.read()
@@ -575,7 +654,9 @@ def do_patch_grub_cfg_icons(icons):
 
     info(f"{len(icons)} icons successfully patched onto {GRUB_CFG_PATH}")
 
+
 def do_set_icons(patch_grubcfg):
+
     icons = user_args.icons
 
     if icons is None:
@@ -625,7 +706,10 @@ def do_set_icons(patch_grubcfg):
         with open(GRUB_MKCONFIG_PATH, "w") as f:
             f.write(new_grub_mkconfig)
 
-        info(f"{GRUB_MKCONFIG_PATH} successfully patched, icons will now persist between grub updates.")
+        info(
+            f"{GRUB_MKCONFIG_PATH} successfully patched, icons will now persist between grub updates."
+        )
+
 
 def install_hookcheck():
     info(f"Create hook check script")
@@ -655,7 +739,9 @@ def install_hookcheck():
     st = os.stat(script_file_path)
     os.chmod(script_file_path, st.st_mode | 0o111)
 
+
 # Script arguments
+
 
 def parse_args():
     parser = ArgumentParser(
@@ -772,12 +858,14 @@ def parse_args():
         help="set grub entries icons using config file. "
     )
     parser.add_argument(
-      "--all-icon-colors",
-      "-aic",
-      nargs="*",
-      help="specify a color for every icon"
+        "--all-icon-colors",
+        "-aic",
+        type=str,
+        nargs="*",
+        help=f"specify colors for each icon separately",
     )
     return parser.parse_args()
+
 
 if __name__ == "__main__":
     try:

--- a/matter.py
+++ b/matter.py
@@ -774,34 +774,30 @@ def parse_args():
     )
     return parser.parse_args()
 
-# if __name__ == "__main__":
-#     try:
-#         check_python_version()
-#         user_args = parse_args()
-
-#         if user_args.listentries:
-#             do_list_grub_cfg_entries()
-#         elif user_args.buildonly:
-#             prepare_source_dir()
-#         elif user_args.seticons_once:
-#             do_set_icons(patch_grubcfg=False)
-#         elif user_args.seticons:
-#             do_set_icons(patch_grubcfg=True)
-#         elif user_args.uninstall:
-#             do_uninstall()
-#         elif user_args.configicons:
-#             patch_from_config_file()
-#         elif user_args.icons is None:
-#             do_preinstall_hint()
-#         else:
-#             do_install()
-
-#         if user_args.test:
-#                 do_test()
-#     except KeyboardInterrupt:
-#         error("Stop. Script halted by user")
-#         sys.exit(1)
-
 if __name__ == "__main__":
-    user_args = parse_args()
-    prepare_source_dir()
+    try:
+        check_python_version()
+        user_args = parse_args()
+
+        if user_args.listentries:
+            do_list_grub_cfg_entries()
+        elif user_args.buildonly:
+            prepare_source_dir()
+        elif user_args.seticons_once:
+            do_set_icons(patch_grubcfg=False)
+        elif user_args.seticons:
+            do_set_icons(patch_grubcfg=True)
+        elif user_args.uninstall:
+            do_uninstall()
+        elif user_args.configicons:
+            patch_from_config_file()
+        elif user_args.icons is None:
+            do_preinstall_hint()
+        else:
+            do_install()
+
+        if user_args.test:
+                do_test()
+    except KeyboardInterrupt:
+        error("Stop. Script halted by user")
+        sys.exit(1)

--- a/matter.py
+++ b/matter.py
@@ -211,6 +211,12 @@ def convert_icon_svg2png():
             if color != "_":
                 colors.append(color)
 
+        if len(icons) != len(colors):
+            error(
+                "You need select a color for all icons,",
+                "there's one or more color missing"
+            )
+
         svg2png = inkscape_convert_svg2png
 
         for icon in icons:
@@ -222,21 +228,20 @@ def convert_icon_svg2png():
             if exit_code != 0: error(f"Stop. The `{svg2png}` command returned an error")
         
     else:
-        icons = [
-            filename[:-4]
-            for filename in os.listdir(f"icons/")
-            if (filename[:-4] in user_args.icons)
-            if (filename.endswith(".svg"))
-        ]
+        icons = []
+        for icon in user_args.icons:
+            if icon not in icons:
+                icons.append(icon)
+
+        color = (
+            parse_color(user_args.iconcolor)
+            if user_args.iconcolor
+            else parse_color(user_args.foreground)
+        )
 
         for icon in icons:
             src_path = ICON_SVG_PATHF.format(icon)
             dst_path = ICON_PNG_PATHF.format(icon)
-            color = (
-                parse_color(user_args.iconcolor)
-                if user_args.iconcolor
-                else parse_color(user_args.foreground)
-            )
 
             if svg2png == "convert": svg2png = magick_convert_svg2png
             elif svg2png == "inkscape": svg2png = inkscape_convert_svg2png

--- a/matter.py
+++ b/matter.py
@@ -201,17 +201,18 @@ def convert_icon_svg2png():
         command = "inkscape"
     
     if (user_args.all_icon_colors is not None) and (command == "inkscape"):
-        icons = [
-            filename[:-4]
-            for filename in os.listdir(f"icons/")
-            if (filename[:-4] in user_args.icons)
-            if (filename.endswith(".svg"))
-        ]
-        colors = check_colors()
+        icons = []
+        for icon in user_args.icons:
+            if icon not in icons:
+                icons.append(icon)
+        
+        colors = []
+        for color in check_colors():
+            if color != "_":
+                colors.append(color)
 
         svg2png = inkscape_convert_svg2png
 
-        #? Converting Icons
         for icon in icons:
             src_path = ICON_SVG_PATHF.format(icon)
             dst_path = ICON_PNG_PATHF.format(icon)
@@ -219,7 +220,7 @@ def convert_icon_svg2png():
             info(f"Icon: {icon}")
             exit_code = svg2png(colors[icons.index(icon)], src_path, dst_path, whisper=True)
             if exit_code != 0: error(f"Stop. The `{svg2png}` command returned an error")
-
+        
     else:
         icons = [
             filename[:-4]

--- a/matter.py
+++ b/matter.py
@@ -176,7 +176,7 @@ def is_icon_downloaded(icon_name):
     svg_path = ICON_SVG_PATHF.format(icon_name)
     return exists(svg_path)
 
-def convert_icons_svg2png(whisper=False):
+def convert_icons_svg2png():
     if not has_command("inkscape"):
         if not has_command("convert"):
             error("Stop. Both `inkscape` and `convert` command from imagemagick was not found", "Consider installing `inkscape` for the best results")
@@ -191,10 +191,13 @@ def convert_icons_svg2png(whisper=False):
         for _ in user_args.icons:
             try: icons.index(_)
             except ValueError: icons.append(_)
+        print(icons)
 
         for _ in user_args.all_icon_colors:
-            try: colors.index(_)
-            except ValueError: colors.append(parse_color(_))
+            color = parse_color(_)
+            try: colors.index(color)
+            except ValueError: colors.append(color)
+        print(colors)
 
         for _ in icons:
             src_path = ICON_SVG_PATHF.format(_)
@@ -202,6 +205,8 @@ def convert_icons_svg2png(whisper=False):
             info(f"Icon: {_}")
             exit_code = svg2png(colors[icons.index(_)], src_path, dst_path, whisper=True)
             if exit_code != 0: error(f"Stop. The `{command}` command returned an error")
+        print(icons)
+        print(colors)
     else:
         icons = []
 

--- a/svg2png.py
+++ b/svg2png.py
@@ -107,7 +107,6 @@ def magick_convert_svg2png(color, src_path, dst_path, whisper=None):
     )
     return os.system(cmd)
 
-
 # For demostration purposes
 if __name__ == "__main__":
     svg2png = inkscape_convert_svg2png

--- a/svg2png.py
+++ b/svg2png.py
@@ -8,7 +8,6 @@ import xml.dom.minidom
 # Local Matter modules
 from utils import sh, shout, error
 
-
 def inkscape_convert_svg2png(color, src_path, dst_path, whisper=False):
     # SVG_URI = "http://www.w3.org/2000/svg"
     FRAC = 0.6
@@ -98,7 +97,6 @@ def inkscape_convert_svg2png(color, src_path, dst_path, whisper=False):
 
     os.remove(TEMPFILE)
     return exit_code
-
 
 def magick_convert_svg2png(color, src_path, dst_path, whisper=None):
     cmd = (

--- a/svg2png.py
+++ b/svg2png.py
@@ -8,6 +8,7 @@ import xml.dom.minidom
 # Local Matter modules
 from utils import sh, shout, error
 
+
 def inkscape_convert_svg2png(color, src_path, dst_path, whisper=False):
     # SVG_URI = "http://www.w3.org/2000/svg"
     FRAC = 0.6
@@ -98,6 +99,7 @@ def inkscape_convert_svg2png(color, src_path, dst_path, whisper=False):
     os.remove(TEMPFILE)
     return exit_code
 
+
 def magick_convert_svg2png(color, src_path, dst_path, whisper=None):
     cmd = (
         r"convert -trim -scale 36x36 -extent 72x72 -gravity center "
@@ -106,6 +108,7 @@ def magick_convert_svg2png(color, src_path, dst_path, whisper=None):
         rf"{src_path} {dst_path}"
     )
     return os.system(cmd)
+
 
 # For demostration purposes
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -24,6 +24,7 @@ def color_string(string, fg=None):
     endcolor = "\033[0m"
     return f"{COLORS.get(fg, '')}{string}{endcolor}"
 
+
 def info(*lines, **kwargs):
     for line in lines:
         print(f"{color_string('[I] ', fg='cyan')}{line}", **kwargs)
@@ -38,11 +39,14 @@ def warning(*lines, **kwargs):
     for line in lines:
         print(f"{color_string('[W] ', fg='yellow')}{line}", **kwargs)
 
+
 # Shell / external utils
+
 
 def sh(command):
     "Executes command in shell and returns its exit status"
     return run(command, shell=True).returncode
+
 
 def shout(command, silence=False):
     "Executes command in shell and returns its stdout"
@@ -50,6 +54,7 @@ def shout(command, silence=False):
     if not silence:
         print(stdout)
     return stdout
+
 
 def has_command(command):
     return which(command) is not None

--- a/utils.py
+++ b/utils.py
@@ -25,20 +25,20 @@ def color_string(string, fg=None):
     return f"{COLORS.get(fg, '')}{string}{endcolor}"
 
 
-def info(*lines):
+def info(*lines, **kwargs):
     for line in lines:
-        print(f"{color_string('[I] ', fg='cyan')}{line}")
+        print(f"{color_string('[I] ', fg='cyan')}{line}", **kwargs)
 
 
-def error(*lines, should_exit=True):
+def error(*lines, should_exit=True, **kwargs):
     for line in lines:
-        print(f"{color_string('[E] ', fg='lightred')}{line}")
+        print(f"{color_string('[E] ', fg='lightred')}{line}", **kwargs)
     if should_exit:
         exit(1)
 
-def warning(*lines):
+def warning(*lines, **kwargs):
     for line in lines:
-        print(f"{color_string('[W] ', fg='yellow')}{line}")
+        print(f"{color_string('[W] ', fg='yellow')}{line}", **kwargs)
 
 
 # Shell / external utils

--- a/utils.py
+++ b/utils.py
@@ -24,11 +24,9 @@ def color_string(string, fg=None):
     endcolor = "\033[0m"
     return f"{COLORS.get(fg, '')}{string}{endcolor}"
 
-
 def info(*lines, **kwargs):
     for line in lines:
         print(f"{color_string('[I] ', fg='cyan')}{line}", **kwargs)
-
 
 def error(*lines, should_exit=True, **kwargs):
     for line in lines:
@@ -40,14 +38,11 @@ def warning(*lines, **kwargs):
     for line in lines:
         print(f"{color_string('[W] ', fg='yellow')}{line}", **kwargs)
 
-
 # Shell / external utils
-
 
 def sh(command):
     "Executes command in shell and returns its exit status"
     return run(command, shell=True).returncode
-
 
 def shout(command, silence=False):
     "Executes command in shell and returns its stdout"
@@ -55,7 +50,6 @@ def shout(command, silence=False):
     if not silence:
         print(stdout)
     return stdout
-
 
 def has_command(command):
     return which(command) is not None


### PR DESCRIPTION
This option can be called by `--all-icon-colors` or `-aic`, which sets the color of each icon, theres no default color, but you still can use `-ic` to set a global color, or simply not using either. You cannot set more than one color for each icon.
I also removed the double enter from all files.
The `prepare_source_dir()` function is no longer responsible for taking care of which icons will be converted, this is now inside the `convert_icons_svg2png()` function.
